### PR TITLE
Enhance docker workflow

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,8 +1,8 @@
 ### APP ########################################################################
-DATABASE_URL="postgres://Dandoh:dandoh@127.0.0.1:5432/webhaskell?sslmode=disable"
-JWT_SECRET="my_jwt_secret"
+DATABASE_URL=postgres://Dandoh:dandoh@127.0.0.1:5432/webhaskell?sslmode=disable
+JWT_SECRET=my_jwt_secret
 
 ### Docker ENV - PostgreSQL ####################################################
-POSTGRES_PASSWORD="dandoh"
-POSTGRES_USER="Dandoh"
-POSTGRES_DB="webhaskell"
+POSTGRES_PASSWORD=dandoh
+POSTGRES_USER=Dandoh
+POSTGRES_DB=webhaskell

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,20 @@
-FROM haskell:8.6.5
+FROM haskell:8.8.3
 
-### Install PostgreSQL
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list
-RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN apt-get update
-RUN apt-get -y install postgresql-11
-RUN apt-get install libpq-dev
-
-ARG pg_password
-ARG pg_user
-ARG pg_db
-USER postgres
-RUN /etc/init.d/postgresql start && psql --command "CREATE USER $pg_user WITH SUPERUSER PASSWORD '$pg_password';" && createdb -O $pg_user $pg_db
-USER root
-
-### Install dbmate
-RUN curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/releases/download/v1.7.0/dbmate-linux-amd64
-RUN chmod +x /usr/local/bin/dbmate
+### Install libpq-dev for postgres haskell lib to be built & entr for detecting changes and restarting stack 
+RUN apt-get update \
+     && apt-get -y install libpq-dev entr \
+     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/
 
+## Prebuild dependencies 
+COPY stack.* package.yaml /root/
+RUN stack build --only-dependencies
+
+
 COPY ./entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh
-ENTRYPOINT ["/opt/entrypoint.sh"]
 
+COPY . /root
+
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -71,24 +71,19 @@ You can also access Graphql Playground at [http://localhost:8080/graphiql](http:
   $ cp .env.default .env
   ```
 - (Optional) Edit anything you need in the .env file
+
 - Create and start docker containers
   ```terminal
-  $ docker-compose up -d
+  $ docker-compose up
   ```
-- Enter inside the docker workspace container
-  ```terminal
-  $ docker exec -it web-haskell-graphql-postgres-boilerplate_workspace_1 /bin/bash
-  ```
-- Migrations
-  ```terminal
-  $ dbmate up
-  ```
-- Run webserver
-  ```terminal
-  $ stack run
-  ```
+
 - Now you can visit: http://localhost:8080/ in your local machine.
 
+- Migrations will automatically run, and you can run them manually anytime using
+  ```terminal
+  $ docker-compose up dbmate
+  ```
+- Stack will restart whenever you change any .hs file, thanks to [entr](http://eradman.com/entrproject/)
 
 
 ## Contributors
@@ -97,3 +92,4 @@ PR are more than welcome. The only note is we use `ormolu` to format codes.
 
 - [Nhan Thai](https://github.com/dandoh)
 - [Pacific01](https://github.com/Pacific01)
+- [Emad Shaaban](https://github.com/emadshaaban92)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,15 +2,43 @@ version: '3.7'
 
 services:
 
+  db:
+    image: postgres:12.2
+    environment:
+      - POSTGRES_PASSWORD
+      - POSTGRES_USER
+      - POSTGRES_DB
+    volumes: 
+      - db-data:/var/lib/postgresql/data
+
   workspace:
-    build:
-      context: ./
-      dockerfile: Dockerfile
-      args:
-        pg_password: ${POSTGRES_PASSWORD}
-        pg_user: ${POSTGRES_USER}
-        pg_db: ${POSTGRES_DB}
+    build: ./
+    depends_on: 
+      - db
+    environment:
+      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable
+      - JWT_SECRET
     volumes:
-      - ./:/root/
+      - ./app:/root/app
+      - ./images:/root/images
+      - ./src:/root/src
+      - ./.env:/root/.env
+      - ./graphiql.html:/root/graphiql.html
+      - ./schema.graphql:/root/schema.graphql
+      - ./package.yaml:/root/package.yaml
+      - ./stack.yaml:/root/stack.yaml
     ports:
       - 8080:8080
+
+  dbmate:
+    image: amacneil/dbmate:v1.8.0
+    environment:
+      - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable 
+    depends_on: 
+      - db
+    volumes:
+      - ./db:/db/
+    command: --wait up
+
+volumes:
+  db-data:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,6 @@ trap 'kill ${!}; term_handler' SIGTERM
 # wait forever
 while true
 do
-  tail -f /dev/null & wait ${!}
+  ls -d **/*.hs | entr -d -r stack run
 done
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-15.9
+resolver: lts-15.12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
This is just an enhancement to the docker workflow of this boilerplate, I've made the following:

- Use a standalone container for Postgres, and use a volume to keep data outside the container.
- Use a standalone container for dbmate.
- Update resolver to lts-15.12 and Haskell image (and ghc) to 8.8.3.
- Use entr to restart stack whenever any .hs file changes.
- Prebuild dependencies while building the docker image, to avoid having to build them every time we make a new container (Keep our containers ephemeral).

That's it, and btw thanks for this great boilerplate :+1: